### PR TITLE
support the newer libre 2 plus european sensors with 15 days runtime

### DIFF
--- a/Bluetooth/LibreTransmitterMetadata.swift
+++ b/Bluetooth/LibreTransmitterMetadata.swift
@@ -110,7 +110,7 @@ public enum SensorType: String, CustomStringConvertible {
         case 0xDF, 0xA2: self = .libre1
         case 0xE5, 0xE6: self = .libreUS14day
         case 0x70: self = .libreProH
-        case 0xC5, 0x9D: self = .libre2
+        case 0xC5, 0x9D, 0xC6: self = .libre2
         case 0x76: self = patchInfo[3] == 0x02 ? .libre2US : patchInfo[3] == 0x04 ? .libre2CA : patchInfo[2] >> 4 == 7 ? .libreSense : .unknown
         default:
             if patchInfo.count == 24 {


### PR DESCRIPTION
Cherrypick from LoopKit/LibreTransmitter PR 14 to add to trio branch
for reference: https://github.com/JohanDegraeve/xdripswift/commit/d2462dc2b95d17e98a0a1be7682d74ad78e2573d